### PR TITLE
Daemon package instatiation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # VSCode
 .vscode/
+
+# Taskobra Artifacts
+taskobra.sqlite.db

--- a/taskobra/monitor/__main__.py
+++ b/taskobra/monitor/__main__.py
@@ -4,7 +4,7 @@ import logging
 import sys
 import os
 
-from taskobra.orm import get_engine, get_session
+from taskobra.orm import get_engine, get_session, Snapshot
 
 
 def parse_args():
@@ -24,7 +24,7 @@ def create_snapshot(args):
     print(f"SwapMem : {psutil.swap_memory()}")
     print(f"CPU     : {psutil.cpu_percent()}")
     # snapshot = for each metric snapshot.add(metric)
-    yield snapshot
+    return snapshot
 
 def create_database_engine(args):
     if args.database_uri:
@@ -32,8 +32,8 @@ def create_database_engine(args):
 
     if 'DATABASE_URI' in os.environ:
         return get_engine(os.environ.get('DATABASE_URI'))
-    
-    # If the fully resolved database URI is not provided, use the credentials and connect to localhost 
+
+    # If the fully resolved database URI is not provided, use the credentials and connect to localhost
     database_username = args.database_username if args.database_username else os.environ.get('POSTGRES_USER', None)
     database_password = args.database_password if args.database_password else os.environ.get('POSTGRES_PASSWORD', None)
     if (database_password is None) or (database_username is None):
@@ -49,7 +49,7 @@ def main(args):
         snapshot = create_snapshot(args)
         with get_session(bind=database_engine) as session:
             session.add(snapshot)
-            session.commit() 
+            session.commit()
 
 
 if __name__ == "__main__":

--- a/taskobra/monitor/__main__.py
+++ b/taskobra/monitor/__main__.py
@@ -32,6 +32,7 @@ def create_database_engine(args):
         return get_engine(args.database_uri)
 
     if 'DATABASE_URI' in os.environ:
+        print(f" * Connecting to database {os.environ.get('DATABASE_URI')}")
         return get_engine(os.environ.get('DATABASE_URI'))
 
     # If the fully resolved database URI is not provided, use the credentials and connect to localhost
@@ -42,6 +43,7 @@ def create_database_engine(args):
         sys.exit(1)
     else:
         database_uri = f"postgresql://{database_username}:{database_password}@127.0.0.1:5432/taskobra"
+        print(f" * Connecting to database {database_uri}")
         return get_engine(database_uri)
 
 def main(args):

--- a/taskobra/monitor/__main__.py
+++ b/taskobra/monitor/__main__.py
@@ -1,10 +1,11 @@
 import argparse
-import psutil
+import datetime
 import logging
-import sys
 import os
+import psutil
+import sys
 
-from taskobra.orm import get_engine, get_session, Snapshot
+from taskobra.orm import CpuPercent, get_engine, get_session, Snapshot
 
 
 def parse_args():
@@ -17,12 +18,12 @@ def parse_args():
 
 
 def create_snapshot(args):
-    snapshot = Snapshot()
+    snapshot = Snapshot(timestamp=datetime.datetime.now())
     # Call Each function, have each return a metric
-    print(f"Disk    : {psutil.disk_usage('/')}")
-    print(f"VMem    : {psutil.virtual_memory()}")
-    print(f"SwapMem : {psutil.swap_memory()}")
-    print(f"CPU     : {psutil.cpu_percent()}")
+    # print(f"Disk    : {psutil.disk_usage('/')}")
+    # print(f"VMem    : {psutil.virtual_memory()}")
+    # print(f"SwapMem : {psutil.swap_memory()}")
+    snapshot.metrics.append(CpuPercent(core_id=0, mean=psutil.cpu_percent()))
     # snapshot = for each metric snapshot.add(metric)
     return snapshot
 

--- a/taskobra/orm/__init__.py
+++ b/taskobra/orm/__init__.py
@@ -1,6 +1,6 @@
 from .base import get_engine, get_session, ORMBase
 from .components import Component, CPU, GPU, Memory, OperatingSystem, Storage
-from .metrics import Metric
+from .metrics import Metric, CpuPercent
 from .role import Role
 from .user import User
 from .snapshot import Snapshot

--- a/taskobra/orm/metrics/cpu_percent.py
+++ b/taskobra/orm/metrics/cpu_percent.py
@@ -22,8 +22,8 @@ class CpuPercent(Metric):
                 yield metric
 
     def __repr__(self):
-        s = f"<Cpu{self.core_id}Percent({self.mean:.3}"
+        s = f"<Cpu{self.core_id}Percent({100*self.mean:.1f}"
         if self.sample_count > 1:
             s += f" sd:{self.standard_deviation:.3} {self.sample_count})"
-        s += ">"
+        s += ")>"
         return s

--- a/taskobra/web/__init__.py
+++ b/taskobra/web/__init__.py
@@ -11,18 +11,18 @@ from taskobra.web.views import api, ui
 def create_app():
     """
     Taskobra Web Application Factory
-        Constructs Flask WSGI Application 
+        Constructs Flask WSGI Application
     return -- Flask()
     """
-    app = Flask(__name__, 
-            template_folder='static/html',  # Root path for render_template() 
+    app = Flask(__name__,
+            template_folder='static/html',  # Root path for render_template()
             static_folder='static')         # Root Path for url_for('static')
 
-    # Load config from ENV 
+    # Load config from ENV
     app.config['DATABASE_URI'] = os.environ.get('DATABASE_URI', 'sqlite:///taskobra.sqlite.db')
     # TODO: OAuth Key
     # TODO: ???
-    
+    print(f" * Using Database URI {app.config['DATABASE_URI']}")
     # Bind Route Blueprints Packages to the base App
     app.register_blueprint(api.blueprint)
     app.register_blueprint(ui.blueprint)

--- a/taskobra/web/__main__.py
+++ b/taskobra/web/__main__.py
@@ -8,11 +8,11 @@ from tests.utils.data_generators import fake_systems_generator
 
 if __name__ == "__main__":
     """
-    Test entry point for the web application 
+    Test entry point for the web application
         Note: Running in this mode is _not_ recommended for Production Environments
         Debug for the WSGI Werkzeug server is turned ON, which will expose you to remote attacks
         Only ever use this with localhost and test environments!
     """
-    with TestDatabase(f"sqlite:////tmp/taskobra.{os.getpid()}.sqlite.db", fake_systems_generator):
+    with TestDatabase(f"sqlite:////tmp/taskobra.{os.getpid()}.sqlite.db", fake_systems_generator(20)):
         app = create_app()
         app.run(host='localhost', debug=True)

--- a/taskobra/web/views/api.py
+++ b/taskobra/web/views/api.py
@@ -14,7 +14,7 @@ def hostnames():
     systems = [
                                   # Switch Status/Uptime/Misc -> Num Cores / Memory Size / Storage Cap
         {'hostname': system.name,
-        'Cores' : sum([component.core_count for _, component in system.components if isinstance(CPU, component)]),
+        'Cores' : sum([component.core_count for _, component in system.components if isinstance(component, CPU)]),
         'uptime': '00:00:00',
         'misc': '' }
         for system in System.query.all()

--- a/taskobra/web/views/api.py
+++ b/taskobra/web/views/api.py
@@ -8,16 +8,16 @@ blueprint = Blueprint('api', __name__, url_prefix='/api')
 @blueprint.route('/')
 def base():
     return jsonify({})
-    
+
 @blueprint.route('/systems')
 def hostnames():
     systems = [
-                                  # Switch Status/Uptime/Misc -> Num Cores / Memory Size / Storage Cap 
-        {'hostname': system.name, 
-        'Cores' : sum([component.core_count for _, component in system.components if isinstance(CPU, component)])
-        'uptime': '00:00:00', 
+                                  # Switch Status/Uptime/Misc -> Num Cores / Memory Size / Storage Cap
+        {'hostname': system.name,
+        'Cores' : sum([component.core_count for _, component in system.components if isinstance(CPU, component)]),
+        'uptime': '00:00:00',
         'misc': '' }
         for system in System.query.all()
     ]
     return jsonify(systems)
-    
+

--- a/tests/orm/test_Snapshot.py
+++ b/tests/orm/test_Snapshot.py
@@ -4,9 +4,11 @@ from .ORMTestCase import ORMTestCase
 from collections import defaultdict
 from datetime import datetime
 from itertools import chain
+import logging
 from math import log
-from random import shuffle
+import random
 from sqlalchemy import Column, ForeignKey, Integer
+import sys
 from typing import Collection
 from unittest import skip
 from unittest.mock import patch
@@ -85,12 +87,6 @@ class TestSnapshot(ORMTestCase):
         self.assertEqual(merge.metrics[0].sample_count,       snapshot.metrics[0].sample_count)
 
     def test_prune(self):
-        g = snapshot_generator()
-        for _ in range(3):
-            snapshot = next(g)
-            print(snapshot)
-            [print(f"    {metric}") for metric in snapshot.metrics]
-
         snapshots = [
             Snapshot(timestamp=datetime(2020, 3, 9, 9, 53, 53), metrics=[TestSnapshotMetric(field=0, mean=2.0), TestSnapshotMetric(field=1, mean=4.0)], sample_rate=2.0),
             Snapshot(timestamp=datetime(2020, 3, 9, 9, 53, 50), metrics=[TestSnapshotMetric(field=0, mean=2.5), TestSnapshotMetric(field=1, mean=4.5)]),
@@ -134,3 +130,12 @@ class TestSnapshot(ORMTestCase):
                         prune1
                     )
                 )]
+
+    def test_prune_random(self):
+        seed = random.randint(0, 0xFFFFFFFFFFFFFFFF)
+        print(f"(test_prune_random seed=0x{seed:0>16X}) ", end="")
+        sys.stdout.flush()
+        random.seed(seed)
+        snapshot_count = 20000
+        pruned = Snapshot.prune(snapshot_generator(snapshot_count))
+        self.assertEqual(snapshot_count, sum(snapshot.sample_count for snapshot in pruned))

--- a/tests/orm/test_Snapshot.py
+++ b/tests/orm/test_Snapshot.py
@@ -87,7 +87,9 @@ class TestSnapshot(ORMTestCase):
     def test_prune(self):
         g = snapshot_generator()
         for _ in range(3):
-            print(next(g))
+            snapshot = next(g)
+            print(snapshot)
+            [print(f"    {metric}") for metric in snapshot.metrics]
 
         snapshots = [
             Snapshot(timestamp=datetime(2020, 3, 9, 9, 53, 53), metrics=[TestSnapshotMetric(field=0, mean=2.0), TestSnapshotMetric(field=1, mean=4.0)], sample_rate=2.0),

--- a/tests/orm/test_Snapshot.py
+++ b/tests/orm/test_Snapshot.py
@@ -9,8 +9,10 @@ from random import shuffle
 from sqlalchemy import Column, ForeignKey, Integer
 from typing import Collection
 from unittest import skip
+from unittest.mock import patch
 # Taskobra
 from taskobra.orm import get_engine, get_session, Metric, Snapshot
+from ..utils.snapshot_generator import snapshot_generator
 
 
 class TestSnapshotMetric(Metric):
@@ -83,6 +85,10 @@ class TestSnapshot(ORMTestCase):
         self.assertEqual(merge.metrics[0].sample_count,       snapshot.metrics[0].sample_count)
 
     def test_prune(self):
+        g = snapshot_generator()
+        for _ in range(3):
+            print(next(g))
+
         snapshots = [
             Snapshot(timestamp=datetime(2020, 3, 9, 9, 53, 53), metrics=[TestSnapshotMetric(field=0, mean=2.0), TestSnapshotMetric(field=1, mean=4.0)], sample_rate=2.0),
             Snapshot(timestamp=datetime(2020, 3, 9, 9, 53, 50), metrics=[TestSnapshotMetric(field=0, mean=2.5), TestSnapshotMetric(field=1, mean=4.5)]),

--- a/tests/utils/TestDatabase.py
+++ b/tests/utils/TestDatabase.py
@@ -1,11 +1,11 @@
-import os 
+import os
 from sqlalchemy.orm import sessionmaker
 from taskobra.orm import get_engine, ORMBase
 
 
 class TestDatabase(object):
     def __init__(self, database_uri, data_generator):
-        # Initialize the databse 
+        # Initialize the databse
         self.database_uri = database_uri
         self.data_generator = data_generator
         self.engine = get_engine(self.database_uri)
@@ -13,8 +13,8 @@ class TestDatabase(object):
         ORMBase.metadata.create_all(self.session.bind)
 
     def __enter__(self):
-        # Generate and commit the test data 
-        for db_object in self.data_generator():
+        # Generate and commit the test data
+        for db_object in self.data_generator:
             self.session.add(db_object)
         self.session.commit()
 

--- a/tests/utils/data_generators.py
+++ b/tests/utils/data_generators.py
@@ -1,7 +1,8 @@
 from taskobra.orm import Component, Storage, System, CPU, GPU, Memory, OperatingSystem
 
-def fake_systems_generator():
-    for index in range(0,10):
+def fake_systems_generator(max_systems=None):
+    count = 0
+    while not max_systems or count < max_systems:
         cpu = CPU(
             manufacturer="AMD",
             model="Ryzen 3800X",
@@ -43,7 +44,7 @@ def fake_systems_generator():
             developer="Microsoft",
             name="Windows 10",
         )
-        system = System(name=f"System {index}")
+        system = System(name=f"System {count}")
         system.add_component(cpu)
         system.add_component(gpu)
         system.add_component(memory)
@@ -51,3 +52,4 @@ def fake_systems_generator():
         system.add_component(storage)
         system.add_component(os)
         yield system
+        count += 1

--- a/tests/utils/snapshot_generator.py
+++ b/tests/utils/snapshot_generator.py
@@ -7,20 +7,49 @@ import taskobra.monitor.__main__
 def snapshot_generator():
     class Percent(float):
         def __repr__(self):
-            return f"{self:.1f}"
+            return f"{self * 100:0.1f}"
 
-    def mock_disk_usage(_):
+        def __str__(self):
+            return repr(self)
+
+    def mock_disk_usage(*_, **__):
         disk_usage = namedtuple("sdiskusage", ["total", "used", "free", "percent"])
         total = randint(1, 500000000000)
         used = randint(0, total)
-        return disk_usage(total, used, total-used, Percent(100*used/total))
+        return disk_usage(total, used, total-used, Percent(used/total))
+
+    def mock_virtual_memory(*_, **__):
+        virtual_memory = namedtuple("svmem", ["total", "available", "percent", "used", "free", "active", "inactive", "buffers", "cached", "shared", "slab",])
+        total = randint(1, 35000000000)
+        available = randint(0, total)
+        percent = Percent(available/total)
+        used = total - available
+        free = randint(0, available)
+        active = randint(0, used)
+        inactive = used - active
+        buffers = randint(0, used)
+        cached = randint(0, used)
+        shared = randint(0, used)
+        slab = randint(0, used)
+        return virtual_memory(total, available, percent, used, free, active, inactive, buffers, cached, shared, slab)
+
+    def mock_swap_memory(*_, **__):
+        swap_memory = namedtuple("sswap", ["total", "used", "free", "percent", "sin", "sout"])
+        total = randint(1, 64000000000)
+        used = randint(0, total)
+        free = total - used
+        percent = Percent(used/total)
+        sin = randint(0, 100000000000)
+        sout = randint(0, 100000000000)
+        return swap_memory(total, used, free, percent, sin, sout)
+
+    def mock_cpu_percent(*_, **__):
+        return Percent(random())
 
     with patch("taskobra.monitor.__main__.psutil") as mock_psutil:
         mock_psutil.disk_usage.side_effect = mock_disk_usage
-
-
-        mock_psutil.virtual_memory.side_effect = lambda: 100 * random()
-        mock_psutil.swap_memory.side_effect = lambda: 100 * random()
-        mock_psutil.cpu_percent.side_effect = lambda: 100 * random()
+        mock_psutil.virtual_memory.side_effect = mock_virtual_memory
+        mock_psutil.swap_memory.side_effect = mock_swap_memory
+        mock_psutil.cpu_percent.side_effect = mock_cpu_percent
         while True:
             yield taskobra.monitor.__main__.create_snapshot([])

--- a/tests/utils/snapshot_generator.py
+++ b/tests/utils/snapshot_generator.py
@@ -1,8 +1,26 @@
-from unittest.mock import patch
-import taskobra.monitor
+from collections import namedtuple
+from unittest.mock import MagicMock, patch
+from random import random, randint
+import taskobra.monitor.__main__
 
 
-@patch("taskobra.monitor.psutil")
-def snapshot_generator(mock_psutil):
-    mock_psutil.disk_usage.__call__ = random.random(0, 100)
-    yield taskobra.monitor.create_snapshot([])
+def snapshot_generator():
+    class Percent(float):
+        def __repr__(self):
+            return f"{self:.1f}"
+
+    def mock_disk_usage(_):
+        disk_usage = namedtuple("sdiskusage", ["total", "used", "free", "percent"])
+        total = randint(1, 500000000000)
+        used = randint(0, total)
+        return disk_usage(total, used, total-used, Percent(100*used/total))
+
+    with patch("taskobra.monitor.__main__.psutil") as mock_psutil:
+        mock_psutil.disk_usage.side_effect = mock_disk_usage
+
+
+        mock_psutil.virtual_memory.side_effect = lambda: 100 * random()
+        mock_psutil.swap_memory.side_effect = lambda: 100 * random()
+        mock_psutil.cpu_percent.side_effect = lambda: 100 * random()
+        while True:
+            yield taskobra.monitor.__main__.create_snapshot([])


### PR DESCRIPTION
`snapshot_generator` now accepts an optional argument for a number to generate then it will quit.
Wrote a unit test that lazy evaluates pruning of 20k snapshots and makes sure the resulting snapshots contain 20k samples.